### PR TITLE
Add ID to pending cancellation alert.

### DIFF
--- a/clientareaproductdetails.tpl
+++ b/clientareaproductdetails.tpl
@@ -7,7 +7,7 @@
 {/if}
 
 {if $pendingcancellation}
-    {include file="$template/includes/alert.tpl" type="error" msg=$LANG.cancellationrequestedexplanation textcenter=true}
+    {include file="$template/includes/alert.tpl" type="error" msg=$LANG.cancellationrequestedexplanation textcenter=true idname="alertpendingcancellation"}
 {/if}
 
 <div class="tab-content margin-bottom">


### PR DESCRIPTION
I submitted this as a bug but the developers said this was the way it was suppose to function....

The main reason for adding the ID is for server module templates that replace the clientareaproductdetails template.  Those modules are forced to use the alert set in the Six theme for pending cancellation requests.  Adding this ID would allow for module templates to easily use JS or CSS to manipulate this alert.

I need this ID so that my module can remove/hide the default alert so that i can display it a different way.