### PR TITLE
Leave bootstrap font-size set to it's defaults

### DIFF
--- a/css/overrides.css
+++ b/css/overrides.css
@@ -20,7 +20,6 @@ button,
 select,
 textarea {
   font-family: "Open Sans", Verdana, Tahoma, serif;
-  font-size: 16px;
   line-height: 1.42857143;
   color: #333333;
 }
@@ -116,20 +115,8 @@ h6 {
     }
 }
 
-.panel {
-  font-size: 0.9em;
-}
-
-.list-group {
-  font-size: 0.9em;
-}
-
 a.list-group-item.active, a.list-group-item.active:hover, a.list-group-item.active:focus {
     background-color: #006687;
-}
-
-.pagination {
-    font-size: 0.8em;
 }
 
 .pagination > .active > a, .pagination > .active > span, .pagination > .active > a:hover, .pagination > .active > span:hover, .pagination > .active > a:focus, .pagination > .active > span:focus {
@@ -158,14 +145,6 @@ input[type='file'].form-control {
 }
 .panel-body {
     padding: 10px 15px;
-}
-
-/* 
- * We use a larger font-size than the bootstrap default, which requires an increase 
- * in the top offset to maintain correct alignment in form control feedback. 
- */
-.has-feedback label ~ .form-control-feedback {
-    top: 27px !important;
 }
 
 .list-group-item > i.fa.fa-circle-o {


### PR DESCRIPTION
I'm confused as to why we are modifying the default font-size for bootstrap.  For whatever reason it's set to 16px but then forced down on things like ```.panel``` and ```.list-group```

The problem i'm seeing is that if you create a table outside a panel or put any text outside a panel or list-group the font is huge and looks horrible.  I removed the font-size on my test env and browsed around the client area and everything looks find, i'm not quiet sure why these were put in place to begin with?

I think a much better idea would be to leave the default font, or set the font accordingly so that every component of bootstrap looks and works like it should, and then set special sizing only for pages/elements that need it. From what i can tell, none of them do! 

Your also setting a font-size of 15 for the navbar, not sure why, it looks fine with the default size i think too.