### PR TITLE
Add article title to the Tweet

### DIFF
--- a/viewannouncement.tpl
+++ b/viewannouncement.tpl
@@ -1,6 +1,6 @@
 {if $twittertweet}
     <div class="pull-right">
-        <a href="https://twitter.com/share" class="twitter-share-button" data-count="vertical" data-via="{$twitterusername}">Tweet</a><script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
+        <a href="https://twitter.com/share" class="twitter-share-button" data-text="{$title}" data-count="vertical" data-via="{$twitterusername}">Tweet</a><script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
     </div>
 {/if}
 


### PR DESCRIPTION
Currently the page title is picked up as the generic "Announcements" page, so adding `data-text="{$title}"` will ensure the article title is included.