### PR TITLE
Move Facebook JS outside of loop

### DIFF
--- a/announcements.tpl
+++ b/announcements.tpl
@@ -1,3 +1,17 @@
+{if $announcementsFbRecommend}
+    <script>
+        (function(d, s, id) {
+            var js, fjs = d.getElementsByTagName(s)[0];
+            if (d.getElementById(id)) {
+                return;
+            }
+            js = d.createElement(s); js.id = id;
+            js.src = "//connect.facebook.net/{$LANG.locale}/all.js#xfbml=1";
+            fjs.parentNode.insertBefore(js, fjs);
+        }(document, 'script', 'facebook-jssdk'));
+    </script>
+{/if}
+
 {foreach from=$announcements item=announcement}
 
     <div class="announcement-single">
@@ -16,17 +30,6 @@
         </blockquote>
 
         {if $announcementsFbRecommend}
-            <script>
-                (function(d, s, id) {
-                    var js, fjs = d.getElementsByTagName(s)[0];
-                    if (d.getElementById(id)) {
-                        return;
-                    }
-                    js = d.createElement(s); js.id = id;
-                    js.src = "//connect.facebook.net/{$LANG.locale}/all.js#xfbml=1";
-                    fjs.parentNode.insertBefore(js, fjs);
-                }(document, 'script', 'facebook-jssdk'));
-            </script>
             <div class="fb-like hidden-sm hidden-xs" data-layout="standard" data-href="{$systemurl}{if $seofriendlyurls}announcements/{$announcement.id}/{$announcement.urlfriendlytitle}.html{else}announcements.php?id={$announcement.id}{/if}" data-send="true" data-width="450" data-show-faces="true" data-action="recommend"></div>
             <div class="fb-like hidden-lg hidden-md" data-layout="button_count" data-href="{$systemurl}{if $seofriendlyurls}announcements/{$announcement.id}/{$announcement.urlfriendlytitle}.html{else}announcements.php?id={$announcement.id}{/if}" data-send="true" data-width="450" data-show-faces="true" data-action="recommend"></div>
         {/if}


### PR DESCRIPTION
Moving the Facebook JS outside of the for-loop will allow it to only load once on the page instead of trying to load for each article displayed.