### PR TITLE
Fixed 'Forgot Password?' link on the OAuth login page.

### DIFF
--- a/oauth/login.tpl
+++ b/oauth/login.tpl
@@ -34,7 +34,7 @@
                         <input type="checkbox" name="rememberme" /> {$LANG.loginrememberme}
                     </label>
                     &bull;
-                    <a href="#">Forgot password?</a>
+                    <a href="/pwreset.php">Forgot password?</a>
                 </div>
             </div>
             <button type="submit" class="btn btn-primary" id="btnLogin">


### PR DESCRIPTION
The 'Forgot password?' link is broken on the OAuth Login page, this fixes it.