### PR TITLE
Create translatable label for NEW notifications

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -39,7 +39,7 @@
                 <li>
                     <a href="#" data-toggle="popover" id="accountNotifications" data-placement="bottom">
                         {$LANG.notifications}
-                        {if count($clientAlerts) > 0}<span class="label label-info">NEW</span>{/if}
+                        {if count($clientAlerts) > 0}<span class="label label-info">{$LANG.notificationsnewlabel}</span>{/if}
                         <b class="caret"></b>
                     </a>
                     <div id="accountNotificationsContent" class="hidden">


### PR DESCRIPTION
This also needs the inclusion of some kind of $_LANG['notificationsnewlabel'] = "NEW";  in the langs file

Currently we're forced to correct this HTML via JQuery, which is not good