### PR TITLE
Widen input in input-group

### DIFF
--- a/viewinvoice.tpl
+++ b/viewinvoice.tpl
@@ -144,7 +144,7 @@
                             <input type="hidden" name="applycredit" value="true" />
                             {$LANG.invoiceaddcreditdesc1} <strong>{$totalcredit}</strong>. {$LANG.invoiceaddcreditdesc2}. {$LANG.invoiceaddcreditamount}:
                             <div class="row">
-                                <div class="col-xs-8 col-xs-offset-2 col-sm-4 col-sm-offset-4">
+                                <div class="col-xs-8 col-xs-offset-2 col-sm-6 col-sm-offset-3">
                                     <div class="input-group">
                                         <input type="text" name="creditamount" value="{$creditamount}" class="form-control" />
                                         <span class="input-group-btn">


### PR DESCRIPTION
This is what is seen with long translation.

<img width="740" alt="Capture d’écran 2020-10-26 à 02 30 26" src="https://user-images.githubusercontent.com/531249/97125149-3d0d8800-1733-11eb-8c8b-60ef0c5f232e.png">

This PR widens the input to actually see the the available credits